### PR TITLE
fix vertex alpha export

### DIFF
--- a/PyNifly/__init__.py
+++ b/PyNifly/__init__.py
@@ -22,7 +22,7 @@ import logging
 import traceback
 import subprocess
 import xml.etree.ElementTree as xml
-from mathutils import Matrix, Vector, Quaternion, Euler, geometry
+from mathutils import Matrix, Vector, Quaternion, Euler, geometry, Color
 import codecs
 import importlib
 
@@ -4369,7 +4369,7 @@ class NifExporter:
             else:
                 c = (1.0, 1.0, 1.0, 1.0)
             if alphamap:
-                a = alphamap[i].color
+                a = Color(alphamap[i].color[0:3]).from_srgb_to_scene_linear()
                 c = (c[0], c[1], c[2], (a[0] + a[1] + a[2])/3)
             loopcolors[i] = c
 


### PR DESCRIPTION
Hello BadDog,

Thank you for sharing this tool. I only recently stumbled on it, and it has been a great help in my workflow.

Now to business. I've added an sRGB->linear colour conversion on export of vertex alpha.

Background:
Blender internally stores colour attributes as sRGB, which doesn't make sense when used to represent non-colour data like alpha. Your exporter never converts the VERTEX_ALPHA colour to actual alpha values, so the NIF ends up with nonsensical sRGB vertex alphas. Moreover, since your importer does convert *to* sRGB, vertex alpha changes if you import a model and export it right back again. The colour conversion fixes these issues.