### PR TITLE
Add Blender 4.2+ Extension Manifest and Automated Release Workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,42 @@
+name: Build Blender Extension
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Blender
+        uses: blender/blender-action@v1
+        with:
+          blender-version: '4.2.0'
+
+      - name: Extract version from Git tag
+        id: get_version
+        run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_ENV
+
+      - name: Update manifest version dynamically
+        run: |
+          python -c "
+          import re
+          with open('blender_manifest.toml', 'r') as f:
+              content = f.read()
+          content = re.sub(r'^version\s*=\s*\".*?\"', f'version = \"${{ env.VERSION }}\"', content, flags=re.M)
+          with open('blender_manifest.toml', 'w') as f:
+              f.write(content)
+          "
+
+      - name: Build Extension Package
+        run: blender --command extension build --output-dir ./dist
+
+      - name: Upload Release Asset
+        uses: softprops/action-gh-release@v2
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: ./dist/*.zip

--- a/blender_manifest.toml
+++ b/blender_manifest.toml
@@ -1,0 +1,16 @@
+schema_version = "1.0.0"
+id = "pynifly"
+version = "28.1.0"
+name = "PyNifly"
+tagline = "Export/Import tools between Blender and the Nif format"
+description = "Export/Import tools between Blender and the Nif format, using Bodyslide/Outfit Studio's Nifly layer. Supports Skyrim LE, Skyrim SE, Fallout 4, and Starfield."
+type = "add-on"
+tags = ["Import-Export"]
+blender_version_min = "4.2.0"
+maintainer = "BadDogSkyrim <https://github.com/BadDogSkyrim>"
+website = "https://github.com/BadDogSkyrim/PyNifly"
+license = [
+    "SPDX:GPL-3.0-only",
+]
+permissions = []
+custom_tags = []


### PR DESCRIPTION
**Description**
This pull request adds support for Blender's native 4.2+ Extension ecosystem by introducing a blender_manifest.toml file along with a GitHub Actions workflow to automate building and releasing extension packages.

**Changes Included**

- blender_manifest.toml: Created in the root directory to define the add-on metadata, compatibility requirements (blender_version_min = "4.2.0"), and repository links for Blender's extension manager.
- 
- .github/workflows/release.yml: Added a CI/CD pipeline that triggers on new version tags (v*). It automatically extracts the version, stamps it into the manifest, builds the official extension .zip package using Blender in headless mode, and attaches it to the GitHub Release.

**Benefits**

- Allows users to discover, install, and update PyNifly natively directly from Blender's Preferences > Extensions menu.
- 
- Fully automates the packaging and release process, preventing version mismatch errors between git tags and the manifest file.